### PR TITLE
Allow targeting any version of net7.0-windows, and also net6.0-windows

### DIFF
--- a/src/FSharp.Maui.WinUICompat/FSharp.Maui.WinUICompat.csproj
+++ b/src/FSharp.Maui.WinUICompat/FSharp.Maui.WinUICompat.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows;net7.0-windows</TargetFramework>
+    <TargetFrameworks>net6.0-windows;net7.0-windows</TargetFrameworks>
     <PackageId>FSharp.Maui.WinUICompat</PackageId>
     <IsPackable>true</IsPackable>
     <UseMaui>true</UseMaui>

--- a/src/FSharp.Maui.WinUICompat/FSharp.Maui.WinUICompat.csproj
+++ b/src/FSharp.Maui.WinUICompat/FSharp.Maui.WinUICompat.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows10.0.18362;net7.0-windows10.0.19041</TargetFrameworks>
     <PackageId>FSharp.Maui.WinUICompat</PackageId>
     <IsPackable>true</IsPackable>
     <UseMaui>true</UseMaui>

--- a/src/FSharp.Maui.WinUICompat/FSharp.Maui.WinUICompat.csproj
+++ b/src/FSharp.Maui.WinUICompat/FSharp.Maui.WinUICompat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net6.0-windows;net7.0-windows</TargetFramework>
     <PackageId>FSharp.Maui.WinUICompat</PackageId>
     <IsPackable>true</IsPackable>
     <UseMaui>true</UseMaui>


### PR DESCRIPTION
Currently, this repository is targeting `net7.0-windows10.0.19041`. I wonder if we can allow targeting lower Windows versions if we change the tfm to `net7.0-windows`.
Also try to support `net6.0-windows`.